### PR TITLE
Revert "Region test 01"

### DIFF
--- a/createxml.ps1
+++ b/createxml.ps1
@@ -24,12 +24,6 @@ $UnattendXml = [xml] @'
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="oobeSystem">
-        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-            <InputLocale>en-US</InputLocale>
-            <SystemLocale>en-US</SystemLocale>
-            <UILanguage>en-US</UILanguage>
-            <UserLocale>en-US</UserLocale>
-        </component>
         <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <OOBE>
                 <ProtectYourPC>3</ProtectYourPC>
@@ -39,6 +33,20 @@ $UnattendXml = [xml] @'
             <RegisteredOrganization>Linklaters</RegisteredOrganization>
             <RegisteredOwner>Linklaters User</RegisteredOwner>
             <TimeZone>UTC</TimeZone>
+        </component>
+        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UserLocale>en-US</UserLocale>
+        </component>
+    </settings>
+    <settings pass="specialize">
+        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UserLocale>en-US</UserLocale>
         </component>
     </settings>
     <cpi:offlineImage cpi:source="wim:c:/win11-unattend/sources/install.wim#Windows 11 Enterprise" xmlns:cpi="urn:schemas-microsoft-com:cpi" />
@@ -116,6 +124,7 @@ $boottowindows = [xml] @"
     <cpi:offlineImage cpi:source="wim:c:/win11-unattend/sources/install.wim#Windows 11 Enterprise" xmlns:cpi="urn:schemas-microsoft-com:cpi" />
 </unattend>
 "@
+
 
 
 foreach ($setting in $unattendXml.Unattend.Settings) {

--- a/startauditmode.ps1
+++ b/startauditmode.ps1
@@ -35,7 +35,7 @@ foreach($setting in $unfile.Unattend.Settings)
     }
 }
 write-host "Starting Sysprep with Reboot"
-start-process -filepath "c:\windows\system32\sysprep\sysprep.exe" -argumentlist "/quiet /reboot /oobe" -wait
+start-process -filepath "c:\windows\system32\sysprep\sysprep.exe" -argumentlist "/quiet /reboot /oobe /unattend:c:\windows\panther\unattend\unattend.xml" -wait
 
 #with reboot
 exit 1


### PR DESCRIPTION
Result:

First pass xml seems to apply what is set in unattend.xml. Post Sysprep all settings are reset apart from Input Language.

###  Audit Mode:

- Format = UK ( Match display....)
- Language for Uni-Code = US
- Display Language = US
- Input Language = UK
- Format = UK
- Location = US

### Post Sysprep

- Format = US ( Match display....) 
- Language for Uni-Code = US
- Display Language = US
- Input Language = UK
- Format = US
- Location = US

### Expectation post Sysprep


- Format = UK 
- Language for Uni-Code = US
- Display Language = US
- Input Language = UK
- Format = UK
- Location = UK

